### PR TITLE
Allow hosts param to create multi servers for Stomp ConnectFailover

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,5 +1,6 @@
 const DEFAULT_HOST = {
     staging: 'https://staging.rizefs.com',
+    release: 'https://release.rizefs.com',
     sandbox: 'https://sandbox.rizefs.com',
     integration: 'https://integration.rizefs.com',
     production: 'https://production.rizefs.com'

--- a/lib/mq/index.js
+++ b/lib/mq/index.js
@@ -16,6 +16,7 @@ class RizeMessageQueue {
 
     /**
      * Connect to the Rize Message Queue server
+     * @param {string} hosts Assign the connection host(s). Comma delimited string.
      * @param {string} clientId Assign a client ID
      * @param {string} topic Your Rize Message Queue base topic
      * @param {string} username Your Rize Message Queue username
@@ -23,13 +24,15 @@ class RizeMessageQueue {
      * @param {RizeMessageQueueConnectOptions} [options]
      * @returns {RizeMessageQueueClient} A RizeMessageQueueClient instance
      */
-    connect(clientId, topic, username, password, options) {
+    connect(hosts, clientId, topic, username, password, options) {
         const opts = options || {};
 
         const environment = opts.environment || this._environment;
 
-        const connectOptions = {
-            'host': 'b-cdfaa84a-a94d-4401-9520-931f5c2293c7-1.mq.us-east-1.amazonaws.com',
+        const parsedHosts = hosts.replace(/\s/g, '').split(',');
+
+        const servers = parsedHosts.map(host => ({
+            'host': host,
             'port': 61614,
             'connectHeaders': {
                 'client-id': clientId,
@@ -38,7 +41,7 @@ class RizeMessageQueue {
                 'heart-beat': '5000,5000',
             },
             'ssl': true
-        };
+        }));
 
         const reconnectOptions = {
             maxReconnects: (!isNaN(opts.maxReconnects) && opts.maxReconnects >= 0)
@@ -46,7 +49,7 @@ class RizeMessageQueue {
                 : -1, // Unlimited reconnects
         };
 
-        const connectFailover = new Stomp.ConnectFailover([connectOptions], reconnectOptions);
+        const connectFailover = new Stomp.ConnectFailover(servers, reconnectOptions);
 
         return new RizeMessageQueueClient(connectFailover, { topic, username, environment });
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rizefinance/rize-js",
-  "version": "0.0.5",
+  "version": "0.0.6",
   "description": "Rize API wrapper",
   "main": "index.js",
   "typings": "types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,6 @@
     "url": "git://github.com/RizeFinance/rize-sdks.git"
   },
   "publishConfig": {
-    "registry": "https://npm.pkg.github.com"
+    "registry": "https://npm.pkg.github.com/@rizefinance"
   }
 }


### PR DESCRIPTION
- Added release ENV
- Allow host param for .connect() MQ

## Ticket

## Dependencies
- ...

## Changes
- ...

## Pre-Test Plan
- ...

## Test Plan
1. Pull down this branch.
2. 
