### PR TITLE
Throw detailed error for bad authentication

### DIFF
--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -56,7 +56,7 @@ class Auth {
                     { headers: { 'Authorization': sJwt } }
                 );
             } catch (err) {
-                return new Error()
+                return new Error();
             }
 
             tokenCache.data = response.data.token;

--- a/lib/core/auth.js
+++ b/lib/core/auth.js
@@ -48,11 +48,16 @@ class Auth {
             // Request for a new token
             const sJwt = rs.KJUR.jws.JWS.sign('HS512', sHeader, sPayload, this._hmac);
 
-            const response = await this._api.post(
-                '/auth',
-                undefined,
-                { headers: { 'Authorization': sJwt } }
-            );
+            let response;
+            try {
+                response = await this._api.post(
+                    '/auth',
+                    undefined,
+                    { headers: { 'Authorization': sJwt } }
+                );
+            } catch (err) {
+                return new Error()
+            }
 
             tokenCache.data = response.data.token;
             tokenCache.timestamp = new Date();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@rizefinance/rize-js",
-  "version": "1.0.0-beta.3",
+  "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rizefinance/rize-js",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Rize API wrapper",
   "main": "index.js",
   "typings": "types/index.d.ts",

--- a/test/core/auth.spec.js
+++ b/test/core/auth.spec.js
@@ -26,8 +26,23 @@ const auth = new Auth(
     TOKEN_MAX_AGE
 );
 
+const invalidAuth = new Auth(
+    process.env.RIZE_PROGRAM_ID,
+    'fsdafdsa4eea',
+    api
+);
+
 describe('Auth', () => {
     let token;
+    it('Fails to get token if invalid credentials', async () => {
+        let token;
+        try {
+            token = await invalidAuth.getToken();
+        } finally {
+            expect(token).be.an('error');
+        }
+    });
+
     it('Gets a new auth token', async () => {
         token = await auth.getToken();
         expect(token).to.not.be.empty;


### PR DESCRIPTION
Will now return the API response:
```
{
  status: 401,
  statusText: '',
  data: {
    errors: [
      {
        code: 1004,
        title: 'Unauthorized',
        detail: 'Invalid or expired authentication',
        occurred_at: '2021-07-29T14:53:52.697Z'
      }
    ],
    status: 401
  }
}
```